### PR TITLE
Fix uninitialized sensor bug

### DIFF
--- a/RPi/services/udp-to-influx/udp-to-influx.py
+++ b/RPi/services/udp-to-influx/udp-to-influx.py
@@ -5,7 +5,7 @@ import influxdb
 import datetime
 import math
 
-_units = ['none', 'deg C', 'Pa', '%', 'V', '', 'mg', 'mg', 'mg', '', '']
+_units = ['none', 'deg C', 'Pa', '%', 'V', '', 'mg', 'mg', 'mg', '']
 _types = ['none', 'temperature', 'pressure', 'humidity', 'battery', 'etx', 'acc_x', 'acc_y', 'acc_z', 'move_count']
 root_addr = "fd00::b0e9:c734:1806:20d1"
 pdr_dict = { root_addr:0 }
@@ -38,10 +38,8 @@ class SampleValue:
 
     def __init__(self, raw):
         self.type = raw[0]
-        value_p = sum([v<<(8*(3-i)) for i,v in enumerate(raw[1:5])])
-        if value_p & 0x80000000:
-            value_p -= 0x100000000
-        value_q = sum([v<<(8*(3-i)) for i,v in enumerate(raw[5:9])])
+        value_p = int.from_bytes(raw[1:5], 'big', signed=True)
+        value_q = int.from_bytes(raw[5:9], 'big', signed=False)
         if value_q != 0:
             self.value = float(value_p) / value_q
         else:

--- a/src/application/README.md
+++ b/src/application/README.md
@@ -4,7 +4,7 @@
    - Payload: Name of the device, string up to 16 characters
 2. Network PAN ID
    - MIME: application/vnd.lumenradio.net_panid
-   - Payload: Hex, 8 characters / 4 bytes, MSB first: 13243546
+   - Payload: Hex, 8 characters / 4 bytes, MSB first 
 3. Network encryption key
    - MIME: application/vnd.lumenradio.net_key
    - Payload: Hex string, 32 characters
@@ -43,6 +43,7 @@ containing:
 - 16 bytes name of device, padded with zeroes. Note that a name with 16 bytes
   may not have a null-byte termination
 - 40 bytes parent address
+- 4 byte sequence number, MSB first
 - list of sensor values, 9 bytes each
   - 1 byte type:
     - 0 = no type
@@ -64,4 +65,4 @@ value, calculate P/Q.
 This method makes it possible for the sensor to provide a proper range and
 resolution for presentation.
 
-With this format 10 sensor values can be added before fragmentation occurs.
+With this format 11 sensor values can be added before fragmentation occurs.

--- a/src/application/sensor-value.c
+++ b/src/application/sensor-value.c
@@ -27,7 +27,6 @@ const char *sensor_value_unit_name[] = {
     [SENSOR_VALUE_TYPE_ACC_Y] = "mg",
     [SENSOR_VALUE_TYPE_ACC_Z] = "mg",
     [SENSOR_VALUE_TYPE_MOVE_COUNT] = "",
-    [SENSOR_VALUE_TYPE_SEQ_NO] = ""
 };
 
 const char *sensor_value_type_name[] = {
@@ -41,5 +40,4 @@ const char *sensor_value_type_name[] = {
     [SENSOR_VALUE_TYPE_ACC_Y] = "acc_y",
     [SENSOR_VALUE_TYPE_ACC_Z] = "acc_z",
     [SENSOR_VALUE_TYPE_MOVE_COUNT] = "move_count",
-    [SENSOR_VALUE_TYPE_SEQ_NO] = "seq_no"
 };

--- a/src/application/sensor-value.h
+++ b/src/application/sensor-value.h
@@ -42,8 +42,6 @@ typedef enum {
     SENSOR_VALUE_TYPE_ACC_Y,
     SENSOR_VALUE_TYPE_ACC_Z,
     SENSOR_VALUE_TYPE_MOVE_COUNT,
-    SENSOR_VALUE_TYPE_SEQ_NO
-
 } sensor_value_type_t;
 
 typedef struct {

--- a/src/application/sensors.c
+++ b/src/application/sensors.c
@@ -63,7 +63,6 @@ static sensor_shtc3_ctx_t sensor_shtc3_ctx;
 #if DPS310_ENABLED
 static sensor_dps310_ctx_t sensor_dps310_ctx;
 #endif
-static seq_no_ctx_t seq_no_ctx;
 
 /*
  * List of handlers
@@ -93,7 +92,6 @@ static const sensor_value_t *sensor_values[] = {
     &sensor_lis2dh12_ctx.val_z,
     &sensor_lis2dh12_ctx.val_move_count,
 #endif
-    &seq_no_ctx.seq_no,
     NULL
 };
 
@@ -177,12 +175,6 @@ PROCESS_THREAD(
     /* Enable NFC first when sensors are started */
     nfcif_register_handler(&sensors_nfc_handler);
     sensors_sender_init(&sender_ctx);
-
-    /* Setup sequence numbers for the HBs */
-    memset(&seq_no_ctx, 0, sizeof(seq_no_ctx_t));
-    seq_no_ctx.seq_no.type = SENSOR_VALUE_TYPE_SEQ_NO;
-    seq_no_ctx.seq_no.value_p = 1; // value_p modified only in case of sending HB
-    seq_no_ctx.seq_no.value_q = 1;
 
     /*
      * Start polling

--- a/src/network-metrics/network-metrics.h
+++ b/src/network-metrics/network-metrics.h
@@ -25,10 +25,6 @@ typedef struct {
     mira_bool_t sensor_available;
 } network_metrics_ctx_t;
 
-typedef struct {
-    sensor_value_t seq_no;
-} seq_no_ctx_t;
-
 /**
  * Call and wait to finish to start up
  */


### PR DESCRIPTION
Fix a bug with uninitialized sensors causing no sequence number to be sent
Send sequence number as part of the header
Some minor refactoring to udp to influx